### PR TITLE
Add --print-ifname option to return host facing interface name used

### DIFF
--- a/pipework
+++ b/pipework
@@ -5,6 +5,15 @@ case "$1" in
     --wait)
       WAIT=1
       ;;
+    --quiet)
+      QUIET=1
+      shift
+      ;;
+    --print-ifname)
+      PRINT_IFNAME=1
+      QUIET=1
+      shift
+      ;;
 esac
 
 IFNAME=$1
@@ -35,9 +44,14 @@ fi
 
 [ "$IPADDR" ] || {
     echo "Syntax:"
-    echo "pipework <hostinterface> [-i containerinterface] <guest> <ipaddr>/<subnet>[@default_gateway] [macaddr][@vlan]"
-    echo "pipework <hostinterface> [-i containerinterface] <guest> dhcp [macaddr][@vlan]"
+    echo "pipework [options] <hostinterface> [-i containerinterface] <guest> <ipaddr>/<subnet>[@default_gateway] [macaddr][@vlan]"
+    echo "pipework [options] <hostinterface> [-i containerinterface] <guest> dhcp [macaddr][@vlan]"
     echo "pipework --wait"
+    echo
+    echo " Options:"
+    echo "    --quiet                 Do not print warnings, only fatal errors"
+    echo "    --print-ifname          Print host facing interface name (port name)"
+    echo
     exit 1
 }
 
@@ -200,6 +214,7 @@ ln -s /proc/$NSPID/ns/net /var/run/netns/$NSPID
     GUEST_IFNAME=ph$NSPID$CONTAINER_IFNAME
     ip link add link $IFNAME dev $GUEST_IFNAME type macvlan mode bridge
     ip link set $IFNAME up
+    LOCAL_IFNAME=$IFNAME
 }
 
 ip link set $GUEST_IFNAME netns $NSPID
@@ -227,6 +242,9 @@ then
     IPADDR=$(echo $IPADDR | cut -d/ -f1) 
     ip netns exec $NSPID arping -c 1 -A -I $CONTAINER_IFNAME $IPADDR > /dev/null 2>&1
 else
-    echo "Warning: arping not found; interface may not be immediately reachable"
+    [ -z "$QUIET" ] && echo "Warning: arping not found; interface may not be immediately reachable"
 fi
+
+[ "$PRINT_IFNAME" ] && [ "$LOCAL_IFNAME" ] && echo $LOCAL_IFNAME
+
 exit 0


### PR DESCRIPTION
A script may need to know about the actual host facing interface that
was created for the bridged use case to further manipulate the port.

Adds a new optional --print-ifname option to echo the host facing
interface name. Also adds an optional --quiet option to avoid printing
warnings to make --print-ifname reliable. --quiet is implied if
--print-ifname is set.

Signed-off-by: Thomas Graf tgraf@noironetworks.com
